### PR TITLE
ci: add Fedora 44 build to matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: ["x86_64"]
-        fedora_version: ["43"]
+        fedora_version: ["43", "44"]
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
Adds `44` to fedora_version matrix so consumers (lifeos main image) can pull `latest-f44-x86_64` after their fc44 base bump.